### PR TITLE
Add support for single quotes in binding attributes

### DIFF
--- a/syntaxes/injection.json
+++ b/syntaxes/injection.json
@@ -74,54 +74,6 @@
 					]
 				}
 			]
-		},
-		"q": {
-			"name": "string.quoted.double.ts",
-			"begin": "\"",
-			"beginCaptures": {
-				"0": {
-					"name": "punctuation.definition.string.begin.ts"
-				}
-			},
-			"end": "(\")|((?:[^\\\\\\n])$)",
-			"endCaptures": {
-				"1": {
-					"name": "punctuation.definition.string.end.ts"
-				},
-				"2": {
-					"name": "invalid.illegal.newline.ts"
-				}
-			},
-			"patterns": [
-				{
-					"begin": "(\\S+)\\s*(:)",
-					"beginCaptures": {
-						"1": {
-							"name": "meta.object-literal.key.ts"
-						},
-						"2": {
-							"name": "punctuation.separator.key-value.ts"
-						}
-					},
-					"patterns": [
-						{
-							"include": "source.ts#expressionWithoutIdentifiers"
-						},
-						{
-							"include": "source.ts#identifiers"
-						},
-						{
-							"include": "source.ts#punctuation-accessor"
-						}
-					],
-					"end": "\\s*(,)\\s*|(?=\\s*\")",
-					"endCaptures": {
-						"1": {
-							"name": "punctuation.separator.key-value.ts"
-						}
-					}
-				}
-			]
 		}
 	}
 }

--- a/syntaxes/injection.json
+++ b/syntaxes/injection.json
@@ -34,36 +34,7 @@
 							"name": "meta.embedded.line.js",
 							"patterns": [
 								{
-									"begin": "\"",
-									"beginCaptures": {
-										"0": {
-											"name": "punctuation.definition.string.begin.html"
-										}
-									},
-									"contentName": "meta.objectliteral.ts",
-									"end": "(\")",
-									"endCaptures": {
-										"0": {
-											"name": "punctuation.definition.string.end.html"
-										},
-										"1": {
-											"name": "source.ts-ignored-vscode"
-										}
-									},
-									"patterns": [
-										{
-											"captures": {
-												"0": {
-													"patterns": [
-														{
-															"include": "source.ts#object-member"
-														}
-													]
-												}
-											},
-											"match": "([^\\n\"/]|/(?![/*]))+"
-										}
-									]
+									"include": "#binding-attribute-value"
 								}
 							]
 						},
@@ -72,6 +43,81 @@
 							"name": "invalid.illegal.unexpected-equals-sign.html"
 						}
 					]
+				}
+			]
+		},
+		"binding-attribute-value": {
+			"patterns": [
+				{
+					"begin": "\"",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.html"
+						}
+					},
+					"contentName": "meta.objectliteral.ts",
+					"end": "(\")",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.html"
+						},
+						"1": {
+							"name": "source.ts-ignored-vscode"
+						}
+					},
+					"patterns": [
+						{
+							"captures": {
+								"0": {
+									"patterns": [
+										{
+											"include": "#binding-inner"
+										}
+									]
+								}
+							},
+							"match": "([^\\n\"/]|/(?![/*]))+"
+						}
+					]
+				},
+				{
+					"begin": "'",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.html"
+						}
+					},
+					"contentName": "meta.objectliteral.ts",
+					"end": "(')",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.html"
+						},
+						"1": {
+							"name": "source.ts-ignored-vscode"
+						}
+					},
+					"patterns": [
+						{
+							"captures": {
+								"0": {
+									"patterns": [
+										{
+											"include": "#binding-inner"
+										}
+									]
+								}
+							},
+							"match": "([^\\n'/]|/(?![/*]))+"
+						}
+					]
+				}
+			]
+		},
+		"binding-inner": {
+			"patterns": [
+				{
+					"include": "source.ts#object-member"
 				}
 			]
 		}


### PR DESCRIPTION
Syntax highlighting for single quotes is working:
![trust me, it works](https://user-images.githubusercontent.com/47453366/162259802-b337cf72-5eec-4366-8a2f-880b6af89db3.png)

Fixes #1
